### PR TITLE
Restore compatibility with transformers 5.0, torchaudio 2.10, hf_hub 1.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,13 +35,16 @@ jobs:
           version: latest
           platform: x64
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pytest pytest-cov coverage-badge
-          # Install additional dependencies needed for testing
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          # Use uv: its resolver picks wheel-available versions instead of
+          # backtracking onto unbuildable sdists (unicodecsv py2 syntax,
+          # sentencepiece 0.1.91, ninja 1.9.0 needing skbuild, ...).
+          uv pip install --system -e . pytest pytest-cov coverage-badge
+          if [ -f requirements-dev.txt ]; then uv pip install --system -r requirements-dev.txt; fi
           
       - name: Generate badges
         if: matrix.is-latest

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 TTSDS is a comprehensive benchmark for evaluating the quality of synthetic speech in Text-to-Speech (TTS) systems. It assesses multiple aspects of speech quality including prosody, speaker identity, and intelligibility by comparing synthetic speech with both real speech and noise datasets.
 
-## Version 2.1.1
+## Version 2.1.3
 
-We are excited to release TTSDS 2.1.1 - we fixed some issues with the installation in the latest update.
+We are excited to release TTSDS 2.1.3 - this release restores compatibility with `transformers>=5.0`, `torchaudio>=2.10`, and `huggingface_hub>=1.4`.
 TTSDS2 is multilingual and updated quarterly, with a new dataset every time: you can view the results at https://ttsdsbenchmark.com#leaderboard.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "statsmodels",
   "torch",
   "transformers",
-  "voicerestore",
   "wespeaker-unofficial",
   "phonemizer-fork",
 ]
@@ -70,6 +69,13 @@ exclude = [
 ]
 
 [project.optional-dependencies]
+# `voicerestore` powers the optional VoiceRestoreBenchmark (ENVIRONMENT
+# category, excluded by default). It is split out because its install
+# resolution can backtrack onto an unbuildable ninja sdist on Python 3.10–3.12.
+# Install with `pip install ttsds[voicerestore]` if you need the env category.
+voicerestore = [
+  "voicerestore",
+]
 dev = [
   "mypy>=1.0.0",
   "pytest>=6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
   "pyannote.audio",
   "pyworld",
   "rich",
+  # Pinned lower bound: older sentencepiece releases are sdist-only and
+  # require a system libsentencepiece-dev install to build, which CI doesn't
+  # have. The resolver picks them when backtracking; this keeps it on the
+  # wheel-available path.
+  "sentencepiece>=0.2.0",
   "silero-vad",
   "statsmodels",
   "torch",

--- a/src/ttsds/__about__.py
+++ b/src/ttsds/__about__.py
@@ -8,4 +8,4 @@ This module contains package metadata used both in the PyPI package and the code
 #
 # SPDX-License-Identifier: MIT
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/src/ttsds/benchmarks/environment/voicerestore.py
+++ b/src/ttsds/benchmarks/environment/voicerestore.py
@@ -1,4 +1,5 @@
 import tempfile
+from typing import Optional
 
 import numpy as np
 import librosa
@@ -11,8 +12,30 @@ from ttsds.benchmarks.benchmark import (
     DeviceSupport,
 )
 from ttsds.util.dataset import Dataset
-from voicerestore.restore import ShortAudioRestorer
-from voicerestore.bigvgan import get_mel_spectrogram
+
+
+# Defer the `voicerestore` import until the benchmark is actually instantiated.
+# `voicerestore` pulls in BigVGAN which calls `_from_pretrained` with kwargs
+# (proxies, resume_download) that newer huggingface_hub releases reject. We
+# don't want that to break `import ttsds.ttsds` for callers who never run the
+# environment benchmarks.
+_VR_IMPORT_ERROR: Optional[Exception] = None
+_ShortAudioRestorer = None
+_get_mel_spectrogram = None
+
+
+def _load_voicerestore() -> None:
+    global _ShortAudioRestorer, _get_mel_spectrogram, _VR_IMPORT_ERROR
+    if _ShortAudioRestorer is not None or _VR_IMPORT_ERROR is not None:
+        return
+    try:
+        from voicerestore.restore import ShortAudioRestorer
+        from voicerestore.bigvgan import get_mel_spectrogram
+    except Exception as exc:
+        _VR_IMPORT_ERROR = exc
+        return
+    _ShortAudioRestorer = ShortAudioRestorer
+    _get_mel_spectrogram = get_mel_spectrogram
 
 
 class VoiceRestoreBenchmark(Benchmark):
@@ -30,7 +53,16 @@ class VoiceRestoreBenchmark(Benchmark):
             description="The PESQ of VoiceRestore.",
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.vr = ShortAudioRestorer()
+        _load_voicerestore()
+        if _VR_IMPORT_ERROR is not None:
+            raise ImportError(
+                "voicerestore could not be imported; the VoiceRestore "
+                "benchmark is unavailable on this dep stack. Either install a "
+                "compatible voicerestore/huggingface_hub combo or drop the "
+                "'voicerestore' key from the benchmarks dict passed to "
+                "BenchmarkSuite."
+            ) from _VR_IMPORT_ERROR
+        self.vr = _ShortAudioRestorer()
         self.device = "cpu"
 
     def _to_device(self, device: str):
@@ -64,9 +96,9 @@ class VoiceRestoreBenchmark(Benchmark):
                 start = np.random.randint(0, len(wav) - 32000)
                 wav = wav[start : start + 32000]
             wav = torch.from_numpy(wav).to(self.device).unsqueeze(0)
-            processed_mel = get_mel_spectrogram(wav, self.vr.model.bigvgan_model.h).to(
-                self.device
-            )
+            processed_mel = _get_mel_spectrogram(
+                wav, self.vr.model.bigvgan_model.h
+            ).to(self.device)
             # Restore audio
             restored_mel = self.vr.model.voice_restore.sample(
                 processed_mel.transpose(1, 2),

--- a/src/ttsds/benchmarks/generic/hubert.py
+++ b/src/ttsds/benchmarks/generic/hubert.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, HubertModel
+from transformers import Wav2Vec2FeatureExtractor, HubertModel
 
 import librosa
 
@@ -34,7 +34,7 @@ class HubertBenchmark(Benchmark):
             hubert_layer=hubert_layer,
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/hubert-large-ls960-ft"
         )
         self.model = HubertModel.from_pretrained(hubert_model)

--- a/src/ttsds/benchmarks/generic/mhubert.py
+++ b/src/ttsds/benchmarks/generic/mhubert.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, HubertModel
+from transformers import Wav2Vec2FeatureExtractor, HubertModel
 
 import librosa
 
@@ -34,7 +34,7 @@ class MHubert147Benchmark(Benchmark):
             hubert_layer=hubert_layer,
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/hubert-large-ls960-ft"
         )
         self.model = HubertModel.from_pretrained(hubert_model)

--- a/src/ttsds/benchmarks/generic/wav2vec2.py
+++ b/src/ttsds/benchmarks/generic/wav2vec2.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, Wav2Vec2Model
+from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 import librosa
 
@@ -35,7 +35,7 @@ class Wav2Vec2Benchmark(Benchmark):
             version="1.0.0",
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/wav2vec2-base-960h"
         )
         self.model = Wav2Vec2Model.from_pretrained(wav2vec2_model)

--- a/src/ttsds/benchmarks/generic/wav2vec2_xlsr.py
+++ b/src/ttsds/benchmarks/generic/wav2vec2_xlsr.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, Wav2Vec2Model
+from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 import librosa
 
@@ -35,7 +35,7 @@ class Wav2Vec2XLSRBenchmark(Benchmark):
             version="1.0.0",
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/wav2vec2-base-960h"
         )
         self.model = Wav2Vec2Model.from_pretrained(wav2vec2_model)

--- a/src/ttsds/benchmarks/intelligibility/mwhisper_activations.py
+++ b/src/ttsds/benchmarks/intelligibility/mwhisper_activations.py
@@ -2,7 +2,7 @@ import re
 import tempfile
 
 import torch
-from transformers import WhisperProcessor, WhisperForConditionalGeneration
+from transformers import WhisperFeatureExtractor, WhisperForConditionalGeneration
 
 import numpy as np
 import librosa
@@ -35,7 +35,7 @@ class MWhisperActivationsBenchmark(Benchmark):
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
             version="1.3.0",
         )
-        self.processor = WhisperProcessor.from_pretrained("openai/whisper-small")
+        self.processor = WhisperFeatureExtractor.from_pretrained("openai/whisper-small")
         self.model = WhisperForConditionalGeneration.from_pretrained(
             "openai/whisper-small"
         )

--- a/src/ttsds/benchmarks/intelligibility/w2v2_activations.py
+++ b/src/ttsds/benchmarks/intelligibility/w2v2_activations.py
@@ -1,6 +1,6 @@
 import re
 
-from transformers import Wav2Vec2Processor, Wav2Vec2Model
+from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 import torch
 import numpy as np
@@ -32,7 +32,7 @@ class Wav2Vec2ActivationsBenchmark(Benchmark):
             wav2vec2_model=wav2vec2_model,
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(wav2vec2_model)
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(wav2vec2_model)
         self.model = Wav2Vec2Model.from_pretrained(wav2vec2_model)
         self.model.eval()
         self.device = "cpu"

--- a/src/ttsds/benchmarks/intelligibility/w2v2_xlsr_activations.py
+++ b/src/ttsds/benchmarks/intelligibility/w2v2_xlsr_activations.py
@@ -1,6 +1,6 @@
 import re
 
-from transformers import Wav2Vec2Processor, Wav2Vec2Model
+from transformers import Wav2Vec2FeatureExtractor, Wav2Vec2Model
 
 import torch
 import numpy as np
@@ -32,7 +32,7 @@ class Wav2Vec2XLSRActivationsBenchmark(Benchmark):
             wav2vec2_model=wav2vec2_model,
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(wav2vec2_model)
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(wav2vec2_model)
         self.model = Wav2Vec2Model.from_pretrained(wav2vec2_model)
         self.model.eval()
         self.device = "cpu"

--- a/src/ttsds/benchmarks/intelligibility/whisper_activations.py
+++ b/src/ttsds/benchmarks/intelligibility/whisper_activations.py
@@ -2,7 +2,7 @@ import re
 import tempfile
 
 import torch
-from transformers import WhisperProcessor, WhisperForConditionalGeneration
+from transformers import WhisperFeatureExtractor, WhisperForConditionalGeneration
 
 import numpy as np
 import librosa
@@ -35,7 +35,9 @@ class WhisperActivationsBenchmark(Benchmark):
             supported_devices=[DeviceSupport.CPU, DeviceSupport.GPU],
             version="1.3.0",
         )
-        self.processor = WhisperProcessor.from_pretrained("openai/whisper-small.en")
+        self.processor = WhisperFeatureExtractor.from_pretrained(
+            "openai/whisper-small.en"
+        )
         self.model = WhisperForConditionalGeneration.from_pretrained(
             "openai/whisper-small.en"
         )

--- a/src/ttsds/benchmarks/prosody/hubert_token.py
+++ b/src/ttsds/benchmarks/prosody/hubert_token.py
@@ -3,7 +3,7 @@ import importlib.resources
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, HubertModel
+from transformers import Wav2Vec2FeatureExtractor, HubertModel
 import librosa
 from sklearn.cluster import KMeans
 
@@ -47,7 +47,7 @@ class HubertTokenSRBenchmark(Benchmark):
             cluster_seed=cluster_seed,
             cluster_datasets=cluster_datasets,
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/hubert-large-ls960-ft"
         )
         self.model = HubertModel.from_pretrained(hubert_model)

--- a/src/ttsds/benchmarks/prosody/mhubert_token.py
+++ b/src/ttsds/benchmarks/prosody/mhubert_token.py
@@ -3,7 +3,7 @@ import importlib.resources
 
 import numpy as np
 import torch
-from transformers import Wav2Vec2Processor, HubertModel
+from transformers import Wav2Vec2FeatureExtractor, HubertModel
 import librosa
 from sklearn.cluster import KMeans
 
@@ -47,7 +47,7 @@ class MHubert147TokenSRBenchmark(Benchmark):
             cluster_seed=cluster_seed,
             cluster_datasets=cluster_datasets,
         )
-        self.processor = Wav2Vec2Processor.from_pretrained(
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(
             "facebook/hubert-large-ls960-ft"
         )
         self.model = HubertModel.from_pretrained(hubert_model)

--- a/src/ttsds/benchmarks/speaker/dvector.py
+++ b/src/ttsds/benchmarks/speaker/dvector.py
@@ -4,7 +4,7 @@ import tempfile
 import torch
 import torch.nn as nn
 import torchaudio
-from torchaudio.sox_effects import apply_effects_tensor
+import torchaudio.functional as AF
 from torchaudio.transforms import MelSpectrogram
 
 import numpy as np
@@ -56,7 +56,13 @@ class Wav2Mel(nn.Module):
 
 
 class SoxEffects(nn.Module):
-    """Transform waveform tensors."""
+    """Transform waveform tensors.
+
+    Pure-torch replacement for the ``apply_effects_tensor`` pipeline
+    ``[["channels", "1"], ["rate", str(sr)], ["norm", str(norm_db)]]``:
+    downmix to mono, resample to the target rate, and normalize the peak
+    amplitude to ``norm_db`` dBFS.
+    """
 
     def __init__(
         self,
@@ -66,14 +72,20 @@ class SoxEffects(nn.Module):
         sil_duration: float,
     ):
         super().__init__()
-        self.effects = [
-            ["channels", "1"],  # convert to mono
-            ["rate", f"{sample_rate}"],  # resample
-            ["norm", f"{norm_db}"],  # normalize to -3 dB
-        ]
+        self.target_sample_rate = sample_rate
+        self.norm_db = norm_db
 
     def forward(self, wav_tensor: torch.Tensor, sample_rate: int) -> torch.Tensor:
-        wav_tensor, _ = apply_effects_tensor(wav_tensor, sample_rate, self.effects)
+        if wav_tensor.dim() == 1:
+            wav_tensor = wav_tensor.unsqueeze(0)
+        if wav_tensor.shape[0] > 1:
+            wav_tensor = wav_tensor.mean(dim=0, keepdim=True)
+        if sample_rate != self.target_sample_rate:
+            wav_tensor = AF.resample(wav_tensor, sample_rate, self.target_sample_rate)
+        peak = wav_tensor.abs().max()
+        if peak > 0:
+            target = 10.0 ** (self.norm_db / 20.0)
+            wav_tensor = wav_tensor * (target / peak)
         return wav_tensor
 
 

--- a/src/ttsds/benchmarks/speaker/wespeaker.py
+++ b/src/ttsds/benchmarks/speaker/wespeaker.py
@@ -5,7 +5,7 @@ import wespeaker
 
 import numpy as np
 import librosa
-import soundfile as sf
+import torch
 from pyannote.audio import Model, Inference
 
 
@@ -55,10 +55,14 @@ class WeSpeakerBenchmark(Benchmark):
                 wav = librosa.resample(
                     wav, orig_sr=dataset.sample_rate, target_sr=16000
                 )
-            with tempfile.NamedTemporaryFile(suffix=".wav") as f:
-                sf.write(f.name, wav, 16000)
-                embedding = self.inference(f.name)
-                embedding = [x[1] for x in embedding]
+            # Pass an in-memory dict instead of a temp file so pyannote.audio
+            # uses its waveform path and skips torchcodec/AudioDecoder, which
+            # fails to import on torchaudio 2.10.
+            waveform = torch.from_numpy(np.ascontiguousarray(wav)).float().unsqueeze(0)
+            embedding = self.inference(
+                {"waveform": waveform, "sample_rate": 16000}
+            )
+            embedding = [x[1] for x in embedding]
             if self.measure_std:
                 embedding = np.std(embedding, axis=0)
                 embeddings.append(embedding)

--- a/src/ttsds/ttsds.py
+++ b/src/ttsds/ttsds.py
@@ -129,15 +129,25 @@ BENCHMARKS_ML = {
 
 
 # save https://huggingface.co/datasets/ttsds/noise-reference to cache_dir/noise-reference
-if not (CACHE_DIR / "noise-reference").exists():
-    run(
-        [
-            "git",
-            "clone",
-            "https://huggingface.co/datasets/ttsds/noise-reference",
-            str(CACHE_DIR / "noise-reference"),
-        ],
-        check=True,
+# Uses huggingface_hub.snapshot_download instead of `git clone`, which would
+# only fetch LFS pointer files unless git-lfs is installed globally.
+_NOISE_REF_DIR = CACHE_DIR / "noise-reference"
+_NOISE_REF_TARS = (
+    "noise_all_ones.tar.gz",
+    "noise_all_zeros.tar.gz",
+    "noise_normal_distribution.tar.gz",
+    "noise_uniform_distribution.tar.gz",
+)
+if not all((_NOISE_REF_DIR / name).exists() for name in _NOISE_REF_TARS) or any(
+    (_NOISE_REF_DIR / name).stat().st_size < 1024 for name in _NOISE_REF_TARS
+):
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(
+        repo_id="ttsds/noise-reference",
+        repo_type="dataset",
+        local_dir=str(_NOISE_REF_DIR),
+        allow_patterns=list(_NOISE_REF_TARS),
     )
 
 tar_files = Path(CACHE_DIR / "noise-reference").glob("*.tar.gz")
@@ -253,11 +263,20 @@ class BenchmarkSuite:
             benchmark_kwargs["hubert_token_sr"]["cluster_datasets"] = [
                 reference_datasets[0].sample(min(100, len(reference_datasets[0])))
             ]
+        # Drop environment benchmarks before instantiation so their (often
+        # large) model weights are not downloaded only to be filtered out a
+        # moment later.
+        if not include_environment:
+            env_keys = {"voicerestore", "wada_snr"}
+            benchmarks = {k: v for k, v in benchmarks.items() if k not in env_keys}
         self.benchmarks = {
             k: v(**benchmark_kwargs.get(k, {})) if isinstance(v, type) else v
             for k, v in benchmarks.items()
         }
         if not include_environment:
+            # Belt-and-braces: also drop any env-category benchmarks that
+            # slipped past the key filter (e.g. user-supplied dict with
+            # different keys).
             self.benchmarks = {
                 k: v
                 for k, v in self.benchmarks.items()


### PR DESCRIPTION
## Summary

`ttsds` 2.1.2 broke on the dep stack many downstream evaluation pipelines now pin to (`transformers>=5.0`, `torchaudio>=2.10`, `huggingface_hub>=1.4`). This PR makes the package import-clean and run-clean on that stack while remaining backwards-compatible with the previous one. Bumps to **2.1.3**.

### Concrete failures fixed

1. **`from torchaudio.sox_effects import apply_effects_tensor`** in `dvector.py` — submodule removed in torchaudio 2.10. Replaced with pure-torch mono downmix → `torchaudio.functional.resample` → peak normalize to `norm_db` dBFS. No behavior change at sox's resolution.
2. **`Wav2Vec2Processor.from_pretrained(...)` fails with `OSError: Unable to load vocabulary from file`** on transformers 5.0 (e.g. `facebook/wav2vec2-xlsr-53-espeak-cv-ft`). Every callsite was using only `.input_values`, so switched to `Wav2Vec2FeatureExtractor` — which never tries to load a vocab. Same defensive switch for `WhisperProcessor` → `WhisperFeatureExtractor`.
3. **`voicerestore` import chain breaks** because BigVGAN passes kwargs (`proxies`, `resume_download`) that newer `huggingface_hub` releases reject. Made the `voicerestore` import lazy; `import ttsds.ttsds` no longer triggers it. Instantiating `VoiceRestoreBenchmark` still requires a working voicerestore install, but you now get a clean `ImportError` pointing at the cause.
4. **`BenchmarkSuite` instantiated env benchmarks before dropping them** — meaning `include_environment=False` still downloaded the 1.2GB voicerestore checkpoint. Pre-filter env keys before instantiation; keep the existing post-filter as a fallback for user-supplied dicts.
5. **WeSpeaker blew up with `name 'AudioDecoder' is not defined`** — pyannote.audio conditionally imports `torchaudio.io.AudioDecoder`, which fails silently on torchaudio 2.10. Switched from writing a temp wav and passing the path to `Inference(...)`, to passing the in-memory dict `{"waveform": tensor, "sample_rate": 16000}` — that takes pyannote's waveform code path and never touches `AudioDecoder`.
6. **`noise-reference` bootstrap** used `git clone https://huggingface.co/datasets/ttsds/noise-reference`, which on systems without git-lfs silently writes ~130-byte LFS pointer files and then `TarDataset` blows up. Switched to `huggingface_hub.snapshot_download(repo_type="dataset", allow_patterns=[...])`, already a transitive dep. Existing broken caches are detected by a size check and re-downloaded.

### Validated end-to-end

Built a fresh venv with `torch==2.10.0`, `torchaudio==2.10.0`, `transformers==5.0.0`, `huggingface_hub==1.4.0`, `librosa==0.11.0`, `soundfile==0.13.1`, `numpy==1.26.4`, plus other transitive deps. Ran the full default `BENCHMARKS` dict against a slice of `ttsds/listening_test` (10 wavs each from `xtts_2`, `styletts2`, with `fishspeech_1_5` as reference):

| benchmark | category | styletts2 | xtts_2 |
|---|---|---|---|
| Allosaurus SR | PROSODY | 93.18 | 87.83 |
| DVector | SPEAKER | 83.96 | 76.32 |
| Hubert | GENERIC | 92.32 | 91.20 |
| Hubert Token SR | PROSODY | 84.61 | 79.32 |
| MPM | PROSODY | 96.47 | 97.84 |
| Pitch | PROSODY | 90.74 | 94.37 |
| Wav2Vec2 | GENERIC | 92.63 | 91.08 |
| Wav2Vec2 Activations | INTELLIGIBILITY | 96.51 | 95.79 |
| WavLM | GENERIC | 96.03 | 95.00 |
| WeSpeaker | SPEAKER | 61.74 | 62.08 |
| Whisper Activations | INTELLIGIBILITY | 67.62 | 67.90 |

All 11 default benchmarks succeed (10/11 even without the WeSpeaker change). Absolute numbers aren't meaningful at this slice size — the point is the pipeline runs to completion.

## Test plan

- [x] All benchmark modules import cleanly on the dep stack above
- [x] `Wav2Vec2XLSRActivationsBenchmark()` instantiates (the originally-reported failure mode)
- [x] `BenchmarkSuite.run()` completes against `ttsds/listening_test` with the default `BENCHMARKS` dict, `include_environment=False`
- [x] `voicerestore` is not instantiated when `include_environment=False` (confirmed: no 1.2GB checkpoint download)
- [ ] CI on the existing test matrix
- [ ] Multilingual stack (`BENCHMARKS_ML`) end-to-end — not exercised in this PR, but the underlying classes are the same as the English stack with different model IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)